### PR TITLE
Fix old codehaus url

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -33,5 +33,5 @@ The complete source for XStream is bundled. This includes:
 
 -XStream Ccommitters
 
- http://xstream.codehaus.org/
+ http://x-stream.github.io
 


### PR DESCRIPTION
Codehaus no more.  Point to new url.
